### PR TITLE
main: fix set-output command is deprecated warnings

### DIFF
--- a/get-blackduck-report.sh
+++ b/get-blackduck-report.sh
@@ -194,5 +194,5 @@ report_contents=$(get_report_contents)
 echo "| got content information"
 echo
 
-echo "::set-output name=sbom-file::report.zip"
-echo "::set-output name=sbom-contents::${report_contents}"
+echo "sbom-file=report.zip" >> $GITHUB_OUTPUT
+echo "sbom-contents=${report_contents}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
when using the blackduck-report-action as described, GitHub summary reports [deprecation warnings related to set-output](see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/). This is fixed in this pull request.