### PR TITLE
fix: Url encode

### DIFF
--- a/get-blackduck-report.sh
+++ b/get-blackduck-report.sh
@@ -29,8 +29,8 @@ function get_bearer {
 }
 
 function get_project_id {
-  result=$(curl --silent --location --request GET --data-urlencode "q=name:$project" "${blackduck_url}/api/projects" \
-    --header "Authorization: Bearer $bearer_token")
+  result=$(curl --silent -G "${blackduck_url}/api/projects" --data-urlencode "q=name:${project}" \
+      --header "Authorization: Bearer ${bearer_token}" )
   if [ "$(echo "$result" | jq -r .totalCount)" -eq 0 ]
   then
     >&2 echo "ERROR: No project found with name: $project"
@@ -41,7 +41,7 @@ function get_project_id {
 }
 
 function get_version_id {
-  result=$(curl --silent --location --request GET --data-urlencode "q=versionName:$version" "$project_api_url/versions" \
+  result=$(curl --silent -G "${project_api_url}/versions" --data-urlencode "q=versionName:${version}" \
     --header "Authorization: Bearer $bearer_token")
   if [ "$(echo "$result" | jq -r .totalCount)" -eq 0 ]
   then
@@ -158,7 +158,7 @@ bearer_token=$(get_bearer)
 echo "| got bearer"
 echo
 
-echo "+ getting project api base url"
+echo "+ getting project api base url for project: ${project}"
 project_api_url=$(get_project_id)
 echo "| got project api base url: ${project_api_url}"
 echo

--- a/get-blackduck-report.sh
+++ b/get-blackduck-report.sh
@@ -81,7 +81,7 @@ function get_report_id {
     fi
     echo "| attempt $retries of $max_retries to get SDPX report"
     sleep 15
-    result=$(curl --silent --location --request GET "$version_api_url/reports" \
+    result=$(curl --silent --location --get "$version_api_url/reports" \
       --header "Authorization: Bearer $bearer_token" \
       --header 'Content-Type: application/json')
     report_api_url=$(echo "$result" | jq -r '.items[0]._meta.href')
@@ -97,14 +97,14 @@ function get_report_id {
 }
 
 function download_sbom_report {
-  curl --silent --location --request GET "$report_api_url/download.zip" \
+  curl --silent --location --get "$report_api_url/download.zip" \
     -o report.zip \
     --header "Authorization: Bearer $bearer_token" \
     --header 'Content-Type: application/zip'
 }
 
 function get_report_contents {
-  curl --silent --location --request GET "$report_api_url/contents" \
+  curl --silent --location --get "$report_api_url/contents" \
     --header "Authorization: Bearer $bearer_token" \
     --header 'Content-Type: application/json' | jq -rc .reportContent[0].fileContent
 }


### PR DESCRIPTION
Currently the filter on project is ignored.

Curl has some nice way of ignoring the `--data-encoded` parameters when using `--request`