### PR TITLE
Re-assign the scan status

### DIFF
--- a/get-blackduck-report.sh
+++ b/get-blackduck-report.sh
@@ -73,6 +73,8 @@ function get_scan_status {
     if [ -z "$scan_status" ];
     then
       scan_status="COMPLETED"
+    else
+      scan_status="IN_PROGRESS"
     fi
     echo "| - scan_status: $scan_status"
   done


### PR DESCRIPTION
*Description:*

The `jq` command will return a JSON object if none of the statuses are in the `COMPLETED` state. The logic of the while loop checks the value of `scan_result` for `IN_PROGRESS` to continue looping. Since `scan_result` will never be `IN_PROGRESS`, it will either be empty (when all statuses match `COMPLETED`) or contain a JSON object. As a result, the loop did not execute. 

This pull request resolves the looping issue: `scan_result` will now be assigned `IN_PROGRESS` when `jq` returns a JSON object, and it will be assigned `COMPLETED` when `jq` returns empty.

*Test Result*
Local tested the method and below is the results:
```
1. When the jq output is empty
| attempt 1 of 50 to get scan status
| - scan_status: COMPLETED
2. When the jq out is non-empty
| attempt 1 of 50 to get scan status
| - scan_status: IN_PROGRESS
| attempt 2 of 50 to get scan status
| - scan_status: IN_PROGRESS
| attempt 3 of 50 to get scan status
| - scan_status: IN_PROGRESS
...
| attempt 48 of 50 to get scan status
| - scan_status: IN_PROGRESS
| attempt 49 of 50 to get scan status
| - scan_status: IN_PROGRESS
| attempt 50 of 50 to get scan status
| - scan_status: IN_PROGRESS
ERROR: max retries reached
```